### PR TITLE
Support `${env:X}` syntax, not just `${env.X}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ The following placeholders are supported:
   workspace. In case of outside-workspace files `${workspaceFolder}` expands
   to the absolute path of the first available workspace.
 - `${cwd}` - replaced by the current working directory of vscode.
-- `${env.VAR}` - replaced by the environment variable $VAR, e.g. `${env.HOME}`will be replaced by`$HOME`, your home directory.
+- `${env:VAR}` - replaced by the environment variable $VAR, e.g. `${env:HOME}`will be replaced by`$HOME`, your home directory.
 
 Some examples:
 
 - `${workspaceRoot}/node_modules/.bin/clang-format` - specifies the version of
   clang that has been added to your workspace by `npm install clang-format`.
-- `${env.HOME}/tools/clang38/clang-format` - use a specific clang format version
+- `${env:HOME}/tools/clang38/clang-format` - use a specific clang format version
   under your home directory.
 
 Placeholders are also supported in `clang-format.assumeFilename`. The supported

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -266,6 +266,22 @@ export class ClangDocumentFormattingEditProvider
     });
   }
 
+  /// Return the input string after replacing placeholders like ${workspaceFolder}
+  // and ${env:X}. The document parameter is used for finding the workspace folder
+  private doStringSubstitutions(input: string, document?: vscode.TextDocument): string {
+    return input
+      .replace(/\${workspaceRoot}/g, this.getWorkspaceFolder(document) ?? "")
+      .replace(/\${workspaceFolder}/g, this.getWorkspaceFolder(document) ?? "")
+      .replace(/\${cwd}/g, process.cwd())
+      .replace(/\${env[.:]([^}]+)}/g, (sub: string, envName: string) => {
+        if (!/^[a-z_]\w*$/i.test(envName)) {
+          outputChannel.appendLine(`Warning: Invalid environment variable name: ${envName}`);
+          return "";
+        }
+        return process.env[envName] ?? "";
+      });
+  }
+
   /// Get execute name in clang-format.executable, if not found, use default value
   /// If configure has changed, it will get the new value
   private getExecutablePath(document?: vscode.TextDocument) {
@@ -281,17 +297,7 @@ export class ClangDocumentFormattingEditProvider
     }
 
     // replace placeholders, if present
-    return execPath
-      .replace(/\${workspaceRoot}/g, this.getWorkspaceFolder(document) ?? "")
-      .replace(/\${workspaceFolder}/g, this.getWorkspaceFolder(document) ?? "")
-      .replace(/\${cwd}/g, process.cwd())
-      .replace(/\${env\.([^}]+)}/g, (sub: string, envName: string) => {
-        if (!/^[a-z_]\w*$/i.test(envName)) {
-          outputChannel.appendLine(`Warning: Invalid environment variable name: ${envName}`);
-          return "";
-        }
-        return process.env[envName] ?? "";
-      });
+    return this.doStringSubstitutions(execPath, document)
   }
 
   private getLanguage(document: vscode.TextDocument): string {
@@ -310,17 +316,7 @@ export class ClangDocumentFormattingEditProvider
 
     let ret = config.get<string>(languageStyleKey) ?? "";
 
-    ret = ret
-      .replace(/\${workspaceRoot}/g, this.getWorkspaceFolder(document) ?? "")
-      .replace(/\${workspaceFolder}/g, this.getWorkspaceFolder(document) ?? "")
-      .replace(/\${cwd}/g, process.cwd())
-      .replace(/\${env\.([^}]+)}/g, (sub: string, envName: string) => {
-        if (!/^[a-z_]\w*$/i.test(envName)) {
-          outputChannel.appendLine(`Warning: Invalid environment variable name: ${envName}`);
-          return "";
-        }
-        return process.env[envName] ?? "";
-      });
+    ret = this.doStringSubstitutions(ret, document);
 
     if (ret.trim()) {
       return ret;
@@ -328,17 +324,7 @@ export class ClangDocumentFormattingEditProvider
 
     // Fallback to global style
     ret = config.get<string>("style") ?? "";
-    ret = ret
-      .replace(/\${workspaceRoot}/g, this.getWorkspaceFolder(document) ?? "")
-      .replace(/\${workspaceFolder}/g, this.getWorkspaceFolder(document) ?? "")
-      .replace(/\${cwd}/g, process.cwd())
-      .replace(/\${env\.([^}]+)}/g, (sub: string, envName: string) => {
-        if (!/^[a-z_]\w*$/i.test(envName)) {
-          outputChannel.appendLine(`Warning: Invalid environment variable name: ${envName}`);
-          return "";
-        }
-        return process.env[envName] ?? "";
-      });
+    ret = this.doStringSubstitutions(ret, document);
 
     const finalStyle = ret.trim() ? ret : this.defaultConfigure.style;
     return finalStyle;


### PR DESCRIPTION
VSCode uses the syntax `${env:X}` for substituting environment variables (see https://code.visualstudio.com/docs/reference/variables-reference#_environment-variables), whereas this extension uses `${env.X}`.

This PR adds support for `${env:X}` in addition to the existing `${env.X}`. It also updates the README to reference the standard `${env:X}` syntax; the nonstandard `${env.X}` is now undocumented (I didn't remove it to avoid inconveniencing people with backwards-compatibility breaks)